### PR TITLE
Define Plan type and fix typecheck errors

### DIFF
--- a/app/components/PlanList.tsx
+++ b/app/components/PlanList.tsx
@@ -20,10 +20,10 @@ export function PlanList({ plans, sortColumn, sortAscending, onSortToggle }: Pla
       <DataTable
         columnContentTypes={["text", "numeric", "text"]}
         headings={[
-          <Button plain onClick={() => onSortToggle("name")} key="h-name">
+          <Button variant="plain" onClick={() => onSortToggle("name")} key="h-name">
             Name {sortColumn === "name" ? (sortAscending ? "▲" : "▼") : ""}
           </Button>,
-          <Button plain onClick={() => onSortToggle("price")} key="h-price">
+          <Button variant="plain" onClick={() => onSortToggle("price")} key="h-price">
             Price {sortColumn === "price" ? (sortAscending ? "▲" : "▼") : ""}
           </Button>,
           "Status",

--- a/app/hooks/useSessionToken.ts
+++ b/app/hooks/useSessionToken.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 
+declare global {
+  interface Window {
+    ShopifyApp?: unknown;
+  }
+}
+
 interface SessionTokenData {
   token: string | null;
   loading: boolean;
@@ -20,7 +26,7 @@ export function useSessionToken(): SessionTokenData & {
       setError(null);
 
       // Prüfe ob App Bridge verfügbar ist
-      if (typeof window !== 'undefined' && (window as any).ShopifyApp) {
+      if (typeof window !== 'undefined' && window.ShopifyApp) {
         try {
           // Echten Session Token von Shopify App Bridge anfordern
           const response = await fetch('/api/session-token', {
@@ -30,7 +36,7 @@ export function useSessionToken(): SessionTokenData & {
             },
             body: JSON.stringify({
               action: 'getSessionToken',
-              shopifyApp: (window as any).ShopifyApp
+              shopifyApp: window.ShopifyApp
             })
           });
 

--- a/app/hooks/useSessionToken.ts
+++ b/app/hooks/useSessionToken.ts
@@ -20,7 +20,7 @@ export function useSessionToken(): SessionTokenData & {
       setError(null);
 
       // Prüfe ob App Bridge verfügbar ist
-      if (typeof window !== 'undefined' && window.ShopifyApp) {
+      if (typeof window !== 'undefined' && (window as any).ShopifyApp) {
         try {
           // Echten Session Token von Shopify App Bridge anfordern
           const response = await fetch('/api/session-token', {
@@ -30,7 +30,7 @@ export function useSessionToken(): SessionTokenData & {
             },
             body: JSON.stringify({
               action: 'getSessionToken',
-              shopifyApp: window.ShopifyApp
+              shopifyApp: (window as any).ShopifyApp
             })
           });
 

--- a/app/routes/api.session-token.tsx
+++ b/app/routes/api.session-token.tsx
@@ -28,15 +28,24 @@ export async function action({ request }: LoaderFunctionArgs) {
     const body = await request.json();
     
     if (body.action === 'getSessionToken') {
-      // Echte Session Token von Shopify anfordern
+      // Echten Session Token von Shopify anfordern
       const { admin, session } = await authenticate.admin(request);
-      
+
       if (!session) {
         return json({ error: "No valid session" }, { status: 401 });
       }
 
-      // Session Token für die aktuelle Session generieren
-      const sessionToken = await (admin as any).sessionToken.create({
+      interface AdminSessionToken {
+        sessionToken: {
+          create: (params: { isOnline: boolean; expires: Date }) => Promise<{
+            token: string;
+            expires: Date;
+          }>;
+        };
+      }
+
+      const adminWithToken = admin as unknown as AdminSessionToken;
+      const sessionToken = await adminWithToken.sessionToken.create({
         isOnline: false,
         expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 Stunden
       });
@@ -46,7 +55,7 @@ export async function action({ request }: LoaderFunctionArgs) {
         sessionToken: sessionToken.token,
         message: "Session token generated successfully",
         type: "real",
-        expires: sessionToken.expires
+        expires: sessionToken.expires,
       });
     }
     

--- a/app/routes/api.session-token.tsx
+++ b/app/routes/api.session-token.tsx
@@ -36,7 +36,7 @@ export async function action({ request }: LoaderFunctionArgs) {
       }
 
       // Session Token für die aktuelle Session generieren
-      const sessionToken = await admin.sessionToken.create({
+      const sessionToken = await (admin as any).sessionToken.create({
         isOnline: false,
         expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 Stunden
       });

--- a/app/routes/app.plans/route.tsx
+++ b/app/routes/app.plans/route.tsx
@@ -1,0 +1,10 @@
+export type Plan = {
+  name: string;
+  priceAmount: number;
+  currencyCode: string;
+  status: string;
+};
+
+export default function Plans() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `Plan` type in new `app.plans` route and provide default component
- fix imports and button props in `PlanList`
- loosen type checks for Shopify-specific globals and admin API

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5ab39b6388333a9e37cdc86877b00