### PR TITLE
Define Plan type and update PlanList

### DIFF
--- a/app/components/PlanList.tsx
+++ b/app/components/PlanList.tsx
@@ -1,5 +1,5 @@
 import { Card, DataTable, Button } from "@shopify/polaris";
-import type { Plan } from "../routes/app.plans/route";
+import type { Plan } from "../routes/app.plans";
 
 export type PlanListProps = {
   plans: Plan[];
@@ -20,10 +20,10 @@ export function PlanList({ plans, sortColumn, sortAscending, onSortToggle }: Pla
       <DataTable
         columnContentTypes={["text", "numeric", "text"]}
         headings={[
-          <Button plain onClick={() => onSortToggle("name")} key="h-name">
+          <Button variant="plain" onClick={() => onSortToggle("name")} key="h-name">
             Name {sortColumn === "name" ? (sortAscending ? "▲" : "▼") : ""}
           </Button>,
-          <Button plain onClick={() => onSortToggle("price")} key="h-price">
+          <Button variant="plain" onClick={() => onSortToggle("price")} key="h-price">
             Price {sortColumn === "price" ? (sortAscending ? "▲" : "▼") : ""}
           </Button>,
           "Status",

--- a/app/routes/app.plans.tsx
+++ b/app/routes/app.plans.tsx
@@ -1,0 +1,10 @@
+export type Plan = {
+  name: string;
+  priceAmount: number;
+  currencyCode: string;
+  status: string;
+};
+
+export default function AppPlans() {
+  return null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",
-    "types": ["node"]
+    "types": ["node", "vitest"]
   }
 }


### PR DESCRIPTION
## Summary
- add `Plan` type in `app/routes/app.plans.tsx`
- update `PlanList` to import the new type and use Polaris button variant
- include `vitest` in TypeScript types

## Testing
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b5d2ace568833387185fa03a3466ff