### PR TITLE
Add DB cleanup on app uninstall

### DIFF
--- a/app/__tests__/webhooks.app.uninstalled.test.ts
+++ b/app/__tests__/webhooks.app.uninstalled.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+
+var testShop: string;
+
+var deleteManyMock: ReturnType<typeof vi.fn>;
+var transactionMock: ReturnType<typeof vi.fn>;
+vi.mock("../db.server", () => {
+  deleteManyMock = vi.fn().mockResolvedValue({ count: 1 });
+  transactionMock = vi.fn(async (operations: Promise<unknown>[]) => {
+    // simulate prisma.$transaction by awaiting all provided promises
+    await Promise.all(operations);
+  });
+  return {
+    __esModule: true,
+    default: {
+      session: { deleteMany: deleteManyMock },
+      $transaction: transactionMock,
+    },
+  };
+});
+
+vi.mock("../shopify.server", () => {
+  testShop = "test-shop.myshopify.com";
+  return {
+    authenticate: {
+      webhook: vi
+        .fn()
+        .mockResolvedValue({ topic: "APP_UNINSTALLED", shop: testShop }),
+    },
+  };
+});
+
+import { action } from "../routes/webhooks.app.uninstalled";
+
+describe("webhooks.app.uninstalled", () => {
+  it("cleans up shop data on uninstall", async () => {
+    const request = new Request("https://example.com", {
+      method: "POST",
+      body: JSON.stringify({ id: 123 }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await action({ request } as any);
+
+    expect(response.status).toBe(200);
+    expect(deleteManyMock).toHaveBeenCalledWith({ where: { shop: testShop } });
+    expect(transactionMock).toHaveBeenCalledOnce();
+  });
+});
+


### PR DESCRIPTION
## Summary
- clean up shop data via Prisma when receiving APP_UNINSTALLED webhooks
- handle webhook auth/cleanup errors with logging and 500 responses
- add unit test covering uninstall cleanup path

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b6eba094b88333b8f1a00a7b4ab966