### PR TITLE
Fix 404 by preserving addAppBlockId slash in admin URL

### DIFF
--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -34,10 +34,11 @@ export default function Index() {
         
         // URL komplett neu konstruieren
         const u = new URL(`https://${shop}/admin/themes/current/editor`);
-        u.searchParams.set('template', templateParam);
-        u.searchParams.set('addAppBlockId', `${apiKey}/${addAppBlockId}`);
-        u.searchParams.set('target', targetParam);
-        
+        const blockIdParam = `${encodeURIComponent(apiKey)}/${encodeURIComponent(addAppBlockId)}`;
+        u.search =
+          `template=${encodeURIComponent(templateParam)}` +
+          `&addAppBlockId=${blockIdParam}` +
+          `&target=${encodeURIComponent(targetParam)}`;
         adminUrl = u.toString();
       } else {
         adminUrl = `https://${shop}/admin/themes/current/editor`;


### PR DESCRIPTION
## Summary
- Avoid `URLSearchParams` from encoding the addAppBlockId path
- Build admin URL query string manually to preserve API key and block handle

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c40417fabc83338f699a60c3fc1d41