### PR TITLE
Update webhook endpoints to new base path

### DIFF
--- a/scripts/re-provision-webhooks.mjs
+++ b/scripts/re-provision-webhooks.mjs
@@ -152,27 +152,27 @@ async function reProvisionWebhooks() {
           webhooks: [
             {
               topic: "app/scopes_update",
-              uri: "/app/webhooks/app/scopes_update",
+              uri: "/webhooks/app/scopes_update",
             },
             {
               topic: "app_subscriptions/update",
-              uri: "/app/webhooks/app/subscriptions_update",
+              uri: "/webhooks/app/subscriptions_update",
             },
             {
               topic: "app/uninstalled",
-              uri: "/app/webhooks/app/uninstalled",
+              uri: "/webhooks/app/uninstalled",
             },
             {
               topic: "customers/data_request",
-              uri: "/app/webhooks/customers/data_request",
+              uri: "/webhooks/customers/data_request",
             },
             {
-              topic: "customers/redact", 
-              uri: "/app/webhooks/customers/redact",
+              topic: "customers/redact",
+              uri: "/webhooks/customers/redact",
             },
             {
               topic: "shop/redact",
-              uri: "/app/webhooks/shop/redact",
+              uri: "/webhooks/shop/redact",
             },
           ],
         });
@@ -185,7 +185,7 @@ async function reProvisionWebhooks() {
 
     console.log("🎉 Webhook re-provisioning completed!");
     console.log("💡 Check webhook deliveries in Partner Dashboard to verify API version 2025-10");
-    console.log("🧹 Note: Old webhooks on /webhooks/* paths may need manual cleanup to avoid duplicates");
+    console.log("🧹 Note: Old webhooks on /app/webhooks/* paths may need manual cleanup to avoid duplicates");
     
   } catch (error) {
     console.error("❌ Re-provisioning failed:", error);

--- a/scripts/test-webhook-endpoints.sh
+++ b/scripts/test-webhook-endpoints.sh
@@ -14,12 +14,12 @@ echo ""
 
 # Webhook-Endpoints mit Topics (portabel für macOS/bash v3.2)
 ENDPOINTS_LIST=$(cat <<'EOF'
-/app/webhooks/app/scopes_update|app/scopes_update
-/app/webhooks/app/subscriptions_update|app_subscriptions/update
-/app/webhooks/app/uninstalled|app/uninstalled
-/app/webhooks/customers/data_request|customers/data_request
-/app/webhooks/customers/redact|customers/redact
-/app/webhooks/shop/redact|shop/redact
+/webhooks/app/scopes_update|app/scopes_update
+/webhooks/app/subscriptions_update|app_subscriptions/update
+/webhooks/app/uninstalled|app/uninstalled
+/webhooks/customers/data_request|customers/data_request
+/webhooks/customers/redact|customers/redact
+/webhooks/shop/redact|shop/redact
 EOF
 )
 

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -12,21 +12,21 @@ embedded = true
 api_version = "2025-10"
 
   [[webhooks.subscriptions]]
-  uri = "/app/webhooks/customers/data_request"
+  uri = "/webhooks/customers/data_request"
   compliance_topics = [ "customers/data_request" ]
 
   [[webhooks.subscriptions]]
-  uri = "/app/webhooks/customers/redact"
+  uri = "/webhooks/customers/redact"
   compliance_topics = [ "customers/redact" ]
 
   [[webhooks.subscriptions]]
-  uri = "/app/webhooks/shop/redact"
+  uri = "/webhooks/shop/redact"
   compliance_topics = [ "shop/redact" ]
 
 
   [[webhooks.subscriptions]]
   topics = [ "app/uninstalled" ]
-  uri = "/app/webhooks/app/uninstalled"
+  uri = "/webhooks/app/uninstalled"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes


### PR DESCRIPTION
## Summary
- point the configured webhook subscriptions to the new /webhooks/* base path
- align helper scripts to register, clean up, and test webhooks against the same endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f237a79ad883338ae152356075a882