### PR TITLE
Fix App Bridge session token integration

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,8 +1,7 @@
 import type { LinksFunction, HeadersFunction, LoaderFunctionArgs } from "@remix-run/node";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
 import { json, type SerializeFrom } from "@remix-run/node";
-import { createContext, type PropsWithChildren, useMemo } from "react";
-import type { ShopifyGlobal } from "@shopify/app-bridge-types";
+import { useMemo } from "react";
 import { I18nManager, I18nContext, useI18n } from "@shopify/react-i18n";
 import { APP_LOCALES, getLocale, type SupportedLocale } from "~/locales";
 
@@ -45,30 +44,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export type RootLoaderData = SerializeFrom<typeof loader>;
-
-const AppBridgeContext = createContext<ShopifyGlobal | null>(null);
-
-type AppBridgeProviderProps = PropsWithChildren<{
-  apiKey: string;
-  host: string;
-  shop: string;
-}>;
-
-function AppBridgeProvider({ apiKey, host, shop, children }: AppBridgeProviderProps) {
-  const value = useMemo(() => {
-    if (typeof window === "undefined") {
-      return null;
-    }
-
-    if (!apiKey || !host) {
-      return null;
-    }
-
-    return window.shopify ?? null;
-  }, [apiKey, host, shop]);
-
-  return <AppBridgeContext.Provider value={value}>{children}</AppBridgeContext.Provider>;
-}
 
 function AppWithTranslations({
   locale,
@@ -119,9 +94,7 @@ export default function App() {
 
   return (
     <I18nContext.Provider value={manager}>
-      <AppBridgeProvider apiKey={apiKey} host={host} shop={shop}>
-        <AppWithTranslations locale={locale} apiKey={apiKey} host={host} shop={shop} />
-      </AppBridgeProvider>
+      <AppWithTranslations locale={locale} apiKey={apiKey} host={host} shop={shop} />
     </I18nContext.Provider>
   );
 }

--- a/app/utils/validateSessionToken.server.ts
+++ b/app/utils/validateSessionToken.server.ts
@@ -31,13 +31,18 @@ function getBasicParams(): SessionValidationParams {
     normalizedUrl.port = process.env.PORT;
   }
 
+  const hostScheme = normalizedUrl.protocol.replace(":", "");
+  if (hostScheme !== "http" && hostScheme !== "https") {
+    throw new Error(`Unsupported host scheme for session token validation: ${hostScheme}`);
+  }
+
   const api = shopifyApi({
     apiKey,
     apiSecretKey: apiSecret,
     apiVersion: ApiVersion.October25,
     scopes: scopes ? scopes.split(",") : [],
     hostName: normalizedUrl.host,
-    hostScheme: normalizedUrl.protocol.replace(":", ""),
+    hostScheme,
     isEmbeddedApp: true,
   });
 


### PR DESCRIPTION
## Summary
- rely on the Shopify App Bridge script and meta tags in the Remix root instead of a custom provider
- wire the dashboard route to use the new App Bridge global, add an authenticated API health check badge, and keep a safe admin navigation fallback
- refresh the authenticated fetch helper and token validator to use idToken(), and update endpoint tests to exercise the secured ping loader

## Testing
- npm run typecheck
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68f220b5015c8333a550bc54a0273426