### PR TITLE
Configure App Bridge bootstrap and session token handling

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -45,6 +45,37 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export type RootLoaderData = SerializeFrom<typeof loader>;
 
+function createAppBridgeConfigScript({
+  apiKey,
+  host,
+  shop,
+}: {
+  apiKey: string;
+  host: string;
+  shop: string;
+}) {
+  if (!apiKey) {
+    return "window.shopify = window.shopify || {};";
+  }
+
+  const config: Record<string, string | boolean> = {
+    apiKey,
+    forceRedirect: true,
+  };
+
+  if (host) {
+    config.host = host;
+  }
+
+  if (shop) {
+    config.shop = shop;
+  }
+
+  const serializedConfig = JSON.stringify(config).replace(/</g, "\\u003C");
+
+  return `window.shopify = window.shopify || {};\nwindow.shopify.config = { ...window.shopify.config, ...${serializedConfig} };`;
+}
+
 function AppWithTranslations({
   locale,
   apiKey,
@@ -71,7 +102,13 @@ function AppWithTranslations({
           <meta name="shopify-api-key" content={apiKey} />
           {host ? <meta name="shopify-host" content={host} /> : null}
           {shop ? <meta name="shopify-shop-domain" content={shop} /> : null}
-          <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js" />
+          <script
+            suppressHydrationWarning
+            dangerouslySetInnerHTML={{
+              __html: createAppBridgeConfigScript({ apiKey, host, shop }),
+            }}
+          />
+          <script src="https://cdn.shopify.com/shopifycloud/app-bridge.js" defer />
           <Meta />
           <Links />
         </head>

--- a/app/utils/authenticatedFetch.ts
+++ b/app/utils/authenticatedFetch.ts
@@ -30,6 +30,10 @@ export function useAuthenticatedFetch() {
 
       if (typeof window !== "undefined") {
         try {
+          if (typeof shopify.ready !== "undefined") {
+            await shopify.ready;
+          }
+
           const token = await shopify.idToken();
           if (token) {
             headers.set("Authorization", `Bearer ${token}`);


### PR DESCRIPTION
## Summary
- embed an inline App Bridge configuration script that hydrates the `window.shopify` global before loading the CDN library
- defer loading the Shopify App Bridge script and await readiness when requesting session tokens for authenticated fetches

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68f361596f1c8333bc5c227682a49d14